### PR TITLE
[HOT-907]: Add embed parameter to posts request

### DIFF
--- a/utils/wordpress.js
+++ b/utils/wordpress.js
@@ -272,10 +272,12 @@ export const getPosts = async (
     'acf',
     'featured_media',
     'featured_media_src_url',
-  ]
+  ],
+  embed = false,
 ) => {
+  const embedParameter = embed ? '&_embed' : ''
   const apiFilters = `?_fields=${fields.join(',')}`
-  const endpoint = `${GATSBY_WP_BASEURL}${REST_PATH}posts${apiFilters}`
+  const endpoint = `${GATSBY_WP_BASEURL}${REST_PATH}posts${apiFilters}${embedParameter}`
 
   // Sticky posts to be shown first
   // TODO: Filter by the vibe or just score by it?


### PR DESCRIPTION
https://vibemap.atlassian.net/browse/HOT-907

We need the `_embed` query parameter to get post authors and other related entities.