### PR TITLE
Fix `activityCategories` import

### DIFF
--- a/utils/wordpress.js
+++ b/utils/wordpress.js
@@ -19,7 +19,7 @@ try {
   console.log('Error with packed vibes ', error)
 }
 
-import activityCategories from '../dist/activityCategories.json'
+import { activityCategories } from '../dist/activityCategories.json'
 
 import cities from '../dist/cities.json'
 


### PR DESCRIPTION
The way `activityCategories` was imported resulted in the variable being and Object (`{ activityCategories: [] }`).
This extracts the property from the imported file.