### PR TITLE
Fix category parent IDs

### DIFF
--- a/dist/activityCategories.json
+++ b/dist/activityCategories.json
@@ -69,7 +69,7 @@
     },
     {
       "id": 6295,
-      "description": "Discover the best things to do in %city%, based on your vibe. Guides, events, activities, and more to help you plan a visit or weekend. Whether you’re a first time visitor or long-time local, we'll recommend something fun and interesting.",
+      "description": "Discover the best things to do in %city%, based on your vibe. Guides, events, activities, and more to help you plan a visit or weekend. Whether you\u2019re a first time visitor or long-time local, we'll recommend something fun and interesting.",
       "name": "All",
       "slug": "all",
       "parent": 0,
@@ -196,7 +196,7 @@
       "description": "",
       "name": "Aquarium",
       "slug": "aquarium",
-      "parent": 6291,
+      "parent": 6298,
       "details": {
         "noun": "Aquarium",
         "sub_categories": [],
@@ -229,7 +229,7 @@
       "description": "",
       "name": "Arcade",
       "slug": "arcade",
-      "parent": 6291,
+      "parent": 6334,
       "details": {
         "noun": "",
         "sub_categories": [],
@@ -322,7 +322,7 @@
         "feature_in_app_": false
       },
       "parent_slug": "art",
-      "level": 3
+      "level": 4
     },
     {
       "id": 6334,
@@ -413,7 +413,7 @@
         "sub_categories": []
       },
       "parent_slug": "art",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9845,
@@ -562,7 +562,7 @@
         "sub_categories": []
       },
       "parent_slug": "beauty",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9932,
@@ -821,7 +821,7 @@
         "sub_categories": []
       },
       "parent_slug": "theater",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9869,
@@ -851,9 +851,10 @@
         "vibes": [],
         "msv": "400",
         "icon": "",
-        "parent_categories": false,
         "sub_categories": []
-      }
+      },
+      "parent_slug": "food",
+      "level": 3
     },
     {
       "id": 9875,
@@ -885,7 +886,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10472,
@@ -901,7 +902,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10638,
@@ -1026,7 +1027,7 @@
       "description": "",
       "name": "Casino",
       "slug": "casino",
-      "parent": 6291,
+      "parent": 6334,
       "details": {
         "noun": "",
         "vibes": [],
@@ -1067,14 +1068,14 @@
         "sub_categories": []
       },
       "parent_slug": "kids",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10439,
       "description": "",
       "name": "Children's Museum",
       "slug": "children_museum",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -1083,7 +1084,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9959,
@@ -1115,7 +1116,7 @@
         "sub_categories": []
       },
       "parent_slug": "religious",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10475,
@@ -1131,7 +1132,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10295,
@@ -1213,7 +1214,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10190,
@@ -1252,7 +1253,7 @@
       "description": "",
       "name": "Club / Dance",
       "slug": "club",
-      "parent": 6570,
+      "parent": 6328,
       "details": {
         "noun": "",
         "vibes": [],
@@ -1332,7 +1333,7 @@
       "description": "",
       "name": "Comedy",
       "slug": "comedy",
-      "parent": 6295,
+      "parent": 6334,
       "details": {
         "noun": "Comedy",
         "vibes": [
@@ -1455,14 +1456,14 @@
         "feature_in_app_": false
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10466,
       "description": "",
       "name": "Conservatory",
       "slug": "conservatory",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -1471,7 +1472,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10370,
@@ -1596,7 +1597,7 @@
       "description": "",
       "name": "Cultural Museum",
       "slug": "cultural_museum",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -1605,7 +1606,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9968,
@@ -1653,7 +1654,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9971,
@@ -1676,7 +1677,7 @@
       "description": "",
       "name": "Design Museum",
       "slug": "design_museum",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -1685,7 +1686,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10343,
@@ -1772,7 +1773,7 @@
       "description": "",
       "name": "DJ",
       "slug": "dj",
-      "parent": 6343,
+      "parent": 6573,
       "details": {
         "noun": "DJ",
         "vibes": [],
@@ -1977,7 +1978,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9992,
@@ -2016,7 +2017,7 @@
       "description": "Explore what's happening in %city%. Make a plan for tonight or this weekend with your events calendar. Explore art, music, nightlife based on your vibe. ",
       "name": "Events",
       "slug": "events",
-      "parent": 0,
+      "parent": 6295,
       "details": {
         "noun": "Events",
         "sub_categories": [
@@ -2095,7 +2096,7 @@
       "description": "",
       "name": "Experiential",
       "slug": "experiential",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -2104,7 +2105,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10478,
@@ -2120,14 +2121,14 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 11658,
       "description": "Ways to get out and have fun with your entire family",
       "name": "Family",
       "slug": "family",
-      "parent": 0,
+      "parent": 6323,
       "details": {
         "noun": "",
         "vibes": [
@@ -2195,7 +2196,7 @@
       "description": "",
       "name": "Festival",
       "slug": "festival",
-      "parent": 6291,
+      "parent": 6323,
       "details": {
         "noun": "",
         "sub_categories": [],
@@ -2228,7 +2229,7 @@
       "description": "",
       "name": "Film",
       "slug": "film",
-      "parent": 6291,
+      "parent": 6334,
       "details": {
         "noun": "",
         "vibes": [],
@@ -2249,7 +2250,7 @@
       "description": "",
       "name": "Film Museum",
       "slug": "film_museum",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -2258,7 +2259,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10677,
@@ -2310,7 +2311,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 6331,
@@ -2388,6 +2389,10 @@
           {
             "id": 9875,
             "slug": "burger"
+          },
+          {
+            "id": 11247,
+            "slug": "buffet"
           },
           {
             "id": 9944,
@@ -2789,7 +2794,7 @@
         "feature_in_app_": true
       },
       "parent_slug": "art",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9905,
@@ -2950,7 +2955,7 @@
         "sub_categories": []
       },
       "parent_slug": "beauty",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10022,
@@ -3049,14 +3054,14 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10454,
       "description": "",
       "name": "History Museum",
       "slug": "history_museum",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -3065,7 +3070,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10355,
@@ -3185,7 +3190,7 @@
       "description": "",
       "name": "Improv",
       "slug": "improv",
-      "parent": 6292,
+      "parent": 6573,
       "details": {
         "msv": "480",
         "noun": "",
@@ -3210,7 +3215,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10034,
@@ -3258,14 +3263,14 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10421,
       "description": "",
       "name": "Interactive",
       "slug": "interactive",
-      "parent": 6291,
+      "parent": 10397,
       "details": {
         "noun": "",
         "sub_categories": [],
@@ -3275,7 +3280,7 @@
         "feature_in_app_": false
       },
       "parent_slug": "theater",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10037,
@@ -3355,7 +3360,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10358,
@@ -3403,7 +3408,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10361,
@@ -3444,7 +3449,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10589,
@@ -3460,7 +3465,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10046,
@@ -3547,7 +3552,7 @@
       "description": "",
       "name": "Lodge",
       "slug": "lodge",
-      "parent": 0,
+      "parent": 6294,
       "details": {
         "noun": "Lodge",
         "vibes": [
@@ -3591,7 +3596,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 11244,
@@ -3604,9 +3609,10 @@
         "vibes": [],
         "msv": "1000",
         "icon": "",
-        "parent_categories": false,
         "sub_categories": []
-      }
+      },
+      "parent_slug": "shop",
+      "level": 3
     },
     {
       "id": 9887,
@@ -3766,7 +3772,7 @@
         "sub_categories": []
       },
       "parent_slug": "religious",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10632,
@@ -3799,7 +3805,7 @@
         "sub_categories": []
       },
       "parent_slug": "film",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10256,
@@ -3888,7 +3894,7 @@
       "description": "",
       "name": "Music",
       "slug": "music",
-      "parent": 6295,
+      "parent": 6334,
       "details": {
         "vibes": [
           "local",
@@ -3995,7 +4001,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10554,
@@ -4011,7 +4017,7 @@
         "sub_categories": []
       },
       "parent_slug": "beauty",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9938,
@@ -4066,7 +4072,7 @@
       "description": "",
       "name": "Nightclub",
       "slug": "nightclub",
-      "parent": 6328,
+      "parent": 6570,
       "details": {
         "noun": "Nightclub",
         "vibes": [
@@ -4079,14 +4085,14 @@
         "sub_categories": []
       },
       "parent_slug": "nightlife",
-      "level": 3
+      "level": 4
     },
     {
       "id": 6570,
       "description": "",
       "name": "Nightlife",
       "slug": "nightlife",
-      "parent": 6295,
+      "parent": 6334,
       "details": {
         "vibes": [
           "latenight",
@@ -4147,7 +4153,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 6340,
@@ -4282,7 +4288,7 @@
       "description": "",
       "name": "Performance",
       "slug": "performance",
-      "parent": 6291,
+      "parent": 6334,
       "details": {
         "noun": "Performing Arts",
         "sub_categories": [
@@ -4388,7 +4394,7 @@
       "description": "",
       "name": "Photography",
       "slug": "photography",
-      "parent": 6291,
+      "parent": 6573,
       "details": {
         "noun": "Photography",
         "vibes": [],
@@ -4436,7 +4442,7 @@
       "description": "",
       "name": "Planetarium",
       "slug": "planetarium",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -4445,7 +4451,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9911,
@@ -4509,7 +4515,7 @@
         "sub_categories": []
       },
       "parent_slug": "art",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10082,
@@ -4557,7 +4563,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10085,
@@ -4589,7 +4595,7 @@
         "sub_categories": []
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10583,
@@ -4605,7 +4611,7 @@
         "sub_categories": []
       },
       "parent_slug": "music-store",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10244,
@@ -4669,7 +4675,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10226,
@@ -4881,6 +4887,10 @@
             "slug": "kids"
           },
           {
+            "id": 11244,
+            "slug": "mall"
+          },
+          {
             "id": 10580,
             "slug": "music-store"
           },
@@ -4932,7 +4942,7 @@
         "sub_categories": []
       },
       "parent_slug": "religious",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10106,
@@ -4997,7 +5007,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10112,
@@ -5333,7 +5343,7 @@
         "vibes": []
       },
       "parent_slug": "comedy",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10253,
@@ -5466,7 +5476,7 @@
         "sub_categories": []
       },
       "parent_slug": "art",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10133,
@@ -5530,14 +5540,14 @@
         "sub_categories": []
       },
       "parent_slug": "beauty",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10145,
       "description": "",
       "name": "Tea",
       "slug": "tea",
-      "parent": 6328,
+      "parent": 6331,
       "details": {
         "noun": "Tea",
         "vibes": [],
@@ -5562,7 +5572,7 @@
         "sub_categories": []
       },
       "parent_slug": "religious",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10229,
@@ -5601,7 +5611,7 @@
       "description": "",
       "name": "Theater",
       "slug": "theater",
-      "parent": 6291,
+      "parent": 10400,
       "details": {
         "noun": "",
         "sub_categories": [
@@ -5620,7 +5630,7 @@
         "feature_in_app_": true
       },
       "parent_slug": "performance",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10382,
@@ -5700,7 +5710,7 @@
         "sub_categories": []
       },
       "parent_slug": "kids",
-      "level": 3
+      "level": 4
     },
     {
       "id": 10151,
@@ -5935,7 +5945,7 @@
       "description": "",
       "name": "Visitor Center",
       "slug": "visitor_center",
-      "parent": 6291,
+      "parent": 10277,
       "details": {
         "noun": "",
         "vibes": [],
@@ -5944,7 +5954,7 @@
         "sub_categories": []
       },
       "parent_slug": "museum",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9878,
@@ -6046,7 +6056,7 @@
         "sub_categories": []
       },
       "parent_slug": "music",
-      "level": 3
+      "level": 4
     },
     {
       "id": 9893,
@@ -6069,7 +6079,7 @@
       "description": "",
       "name": "Zoo",
       "slug": "zoo",
-      "parent": 6291,
+      "parent": 6298,
       "details": {
         "noun": "",
         "sub_categories": [],


### PR DESCRIPTION
This is a fix for [VIBEMAP-1553](https://vibemap.atlassian.net/browse/VIBEMAP-1553) in Jira.
It properly maps the parent IDs according to the parent_slug and other indicators.

[VIBEMAP-1553]: https://vibemap.atlassian.net/browse/VIBEMAP-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ