### PR TITLE
Fix getTaxonomyIds

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -78,15 +78,19 @@ const ApiUrl = `${api_domain}/${api_version}/`
 // Similar to .filter method of array
 export const filterList = (
   list = [{ test: 'test', value: 'foo' }, { test: 'test', value: 'bar' }],
-  searchTerm = 'food', key = 'value'
+  searchTerm = 'food', key = 'value', literal = false
 ) => {
   // Generalize the Semantic UI search implementation
-  const re = new RegExp(searchTerm.replace(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&'), 'i')
+  let results
+  if (literal) {
+    results = list.filter(item => searchTerm === item[key])
+  } else {
+    const re = new RegExp(searchTerm.replace(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&'), 'i')
 
-  const isMatch = (result) => re.test(result[key])
+    const isMatch = (result) => re.test(result[key])
 
-  const results = list.filter(item => isMatch(item))
-
+    results = list.filter(item => isMatch(item))
+  }
   return results
 }
 

--- a/utils/wordpress.js
+++ b/utils/wordpress.js
@@ -70,7 +70,7 @@ export const getTaxonomyIds = (type, filter = ['chill']) => {
     case 'cities':
       return filter.map(slug => {
         // Find taxonomy that match slug
-        const matches = helpers.filterList(helpers.cities, slug, 'slug')
+        const matches = helpers.filterList(helpers.cities, slug, 'slug', true)
 
         const found_id = matches.map(match => match && match.id_wordpress ? match.id_wordpress : match.id)
         return matches.length > 0
@@ -524,6 +524,9 @@ export const getPosts = async (
   // TODO: Filter by the vibe or just score by it?
   const paramsOverride = {
     per_page: per_page,
+    // returns a city ID and converts to string
+    // TODO: Issue is, getTaxonomyIds uses filters.cities which is a name of a city. Then calls on helpers.filterList which regexes that name, compares against static cities.json in vibemap-constants, to return ID
+    // this does the wrong thing for cities like Portland, ME vs Portland, OR
     cities: getTaxonomyIds('cities', filters.cities).toString(),
     sticky: true
   }


### PR DESCRIPTION
For cities, the slugs are unique and we need to distinguish two cities even with identical names. Avoid using regex and do literal match for string slug match