### PR TITLE
do not retry request that throws a 500 error

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,5 +1,5 @@
 import Axios from "axios"
-import axiosRetry from 'axios-retry'
+import axiosRetry, { isNetworkOrIdempotentRequestError } from 'axios-retry'
 
 import querystring from 'querystring'
 
@@ -8,7 +8,10 @@ axiosRetry(Axios, {
   retryDelay: axiosRetry.exponentialDelay,
   onRetry: (count, err, config) => {
     console.log('Axios retrying: ', count, err, config)
-  }
+  },
+  retryCondition: (error) => {
+    return isNetworkOrIdempotentRequestError(error) && error.response.status !== 500;
+  },
 })
 
 // same object, but with updated typings.


### PR DESCRIPTION
Do not retry request that throws a 500 error to prevent requests from places that are closed from being retried when obtaining guide points.

By default the retry is made to only the requests that are Idempotent and now it is also taken into account that the error is not a 500.

@stevepepple  I  couldn't compile the mobile app using axios, so this is a blank fix, when can you please post a new version to test?